### PR TITLE
Update cli flag to use `--format=json` as `--json` is deprecated

### DIFF
--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintExternalRunner.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintExternalRunner.kt
@@ -110,7 +110,7 @@ class TemplateLintExternalRunner(private val myIsOnTheFly: Boolean = false) {
             sessionData.templateLintPackage
                     .addMainEntryJsFile(commandLine, sessionData.interpreter)
 
-            commandLine.addParameter("--json")
+            commandLine.addParameter("--format=json")
 
             val pathToLint = FileUtil.toSystemDependentName(sessionData.fileToLint.path)
             val relativePath = FileUtil.getRelativePath(workDirectory.absolutePath, pathToLint, File.separatorChar)


### PR DESCRIPTION
See https://github.com/ember-template-lint/ember-template-lint/pull/2193

I think this would ideally be combined with some kind of version check to conditionally change the flag.