### PR TITLE
Fix possible NPE when using PsiElement#getText

### DIFF
--- a/src/main/kotlin/com/emberjs/utils/EmberUtils.kt
+++ b/src/main/kotlin/com/emberjs/utils/EmberUtils.kt
@@ -648,13 +648,13 @@ class EmberUtils {
                 }
                 return param
             }
-            if (element is PsiElement && element.text.contains(Regex("^(\\(|\\{\\{)or\\b"))) {
+            if (element is PsiElement && element.text?.contains(Regex("^(\\(|\\{\\{)or\\b")) == true) {
                 val params = element.children.filter { it is HbParam && !it.text.startsWith("@") }.drop(1)
                 return params.find { it.children.firstOrNull()?.children?.firstOrNull()?.references?.isNotEmpty() == true } ?:
                 params.find { it.children.firstOrNull()?.children?.firstOrNull()?.children?.firstOrNull()?.references?.isNotEmpty() == true } ?:
                 params.find { it.text.contains(Regex("^(\\(|\\{\\{)component\\b")) && !it.children.contains(handleEmberHelpers(it)) }?.let { handleEmberHelpers(it) }
             }
-            if (element is PsiElement && element.text.contains(Regex("^(\\(|\\{\\{)if\\b"))) {
+            if (element is PsiElement && element.text?.contains(Regex("^(\\(|\\{\\{)if\\b")) == true) {
                 val params = element.children.filter { it is HbParam && !it.text.startsWith("@") }.drop(1)
                 return params.find { it.children.firstOrNull()?.children?.firstOrNull()?.references?.isNotEmpty() == true } ?:
                 params.find { it.children.firstOrNull()?.children?.firstOrNull()?.children?.firstOrNull()?.references?.isNotEmpty() == true } ?:


### PR DESCRIPTION
I sometimes receive IDE errors with a NPE pointing to 'getText() is null'. Unfortunately I could not create a clean reproduction of this issue, but I do see that an earlier case has been protected against null values.

Whenever an NPE occurs here, it seems that the whole plugin stops working, so this might improve reliability for people affected by the same problem

