### PR TITLE
include .gjs files in index

### DIFF
--- a/src/main/kotlin/com/emberjs/index/EmberNameIndex.kt
+++ b/src/main/kotlin/com/emberjs/index/EmberNameIndex.kt
@@ -28,7 +28,7 @@ class EmberNameIndex : ScalarIndexExtension<Boolean>() {
 
     companion object {
         val NAME: ID<Boolean, Void> = ID.create("ember.names")
-        private val FILE_EXTENSIONS = setOf("css", "scss", "js", "ts", "hbs", "handlebars", "gts")
+        private val FILE_EXTENSIONS = setOf("css", "scss", "js", "ts", "hbs", "handlebars", "gjs", "gts")
 
         val index: FileBasedIndex get() = FileBasedIndex.getInstance()
 

--- a/src/main/kotlin/com/emberjs/index/EmberNameIndex.kt
+++ b/src/main/kotlin/com/emberjs/index/EmberNameIndex.kt
@@ -18,7 +18,7 @@ import com.intellij.util.io.BooleanDataDescriptor
 class EmberNameIndex : ScalarIndexExtension<Boolean>() {
 
     override fun getName() = NAME
-    override fun getVersion() = 7
+    override fun getVersion() = 8
     override fun getKeyDescriptor() = BooleanDataDescriptor.INSTANCE
     override fun dependsOnFileContent() = false
 


### PR DESCRIPTION
This should fix the "Go to class" action:
<img width="152" alt="Screenshot 2024-06-28 at 10 08 28 AM" src="https://github.com/patricklx/intellij-emberjs-experimental/assets/752885/54cad16e-c3cb-418c-8bf6-c438cd0e5b85">
<img width="418" alt="Screenshot 2024-06-28 at 10 08 36 AM" src="https://github.com/patricklx/intellij-emberjs-experimental/assets/752885/2553d7c6-052c-4395-bb90-8b4b72be9605">
