### PR TITLE
fix unused exported vars & functions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.stdlib.default.dependency = false
+org.gradle.jvmargs=-Xmx4g

--- a/src/main/kotlin/com/emberjs/gts/GtsReferenceSearcher.kt
+++ b/src/main/kotlin/com/emberjs/gts/GtsReferenceSearcher.kt
@@ -6,6 +6,7 @@ import com.emberjs.hbs.ResolvedReference
 import com.emberjs.psi.EmberNamedElement
 import com.emberjs.utils.ifTrue
 import com.intellij.lang.ecmascript6.psi.ES6ImportSpecifier
+import com.intellij.lang.javascript.JavaScriptSupportLoader
 import com.intellij.lang.javascript.psi.JSPsiNamedElementBase
 import com.intellij.lang.javascript.psi.JSVariable
 import com.intellij.openapi.application.QueryExecutorBase
@@ -23,66 +24,86 @@ import com.intellij.util.Processor
 
 class GtsReferenceSearcher : QueryExecutorBase<PsiReference?, ReferencesSearch.SearchParameters>(true) {
     override fun processQuery(queryParameters: ReferencesSearch.SearchParameters, consumer: Processor<in PsiReference?>) {
-        val element = queryParameters.elementToSearch
+        var element = queryParameters.elementToSearch
         if (element is JSPsiNamedElementBase) {
             val name = element.name
             if (name != null) {
+                if (element.containingFile is GtsFile){
+                   if (element is JSVariable) {
+                       val psi = element.containingFile.viewProvider.getPsi(JavaScriptSupportLoader.TYPESCRIPT) ?: element.containingFile.viewProvider.getPsi(JavaScriptSupportLoader.ECMA_SCRIPT_6)
+                       element = psi.findElementAt(element.textOffset)?.parent ?: element
+                   }
+                }
                 val effectiveScope = if (element is JSVariable && (queryParameters.effectiveSearchScope as? LocalSearchScope)?.scope?.size == 1) {
                     LocalSearchScope(element.containingFile)
                 } else {
                     queryParameters.effectiveSearchScope
                 }
                 val collector = queryParameters.optimizer
-                collector.searchWord(name, effectiveScope, 1.toShort(), true, element, MyProcessor(queryParameters))
+                collector.searchWord(name, effectiveScope, 1.toShort(), true, element, MyProcessor(queryParameters, element))
             }
         }
     }
 
-    private class MyProcessor(queryParameters: ReferencesSearch.SearchParameters) : RequestResultProcessor() {
+    private class MyProcessor(queryParameters: ReferencesSearch.SearchParameters, elementToSearch: PsiElement) : RequestResultProcessor() {
         private val myQueryParameters: ReferencesSearch.SearchParameters
         private val myOwnCollector: SearchRequestCollector
+        private val myElementToSearch: PsiElement
 
         init {
             myQueryParameters = queryParameters
+            myElementToSearch = elementToSearch
             myOwnCollector = SearchRequestCollector(queryParameters.optimizer.searchSession)
         }
 
         override fun processTextOccurrence(element: PsiElement, offsetInElement: Int, consumer: Processor<in PsiReference>): Boolean {
-            if (myQueryParameters.elementToSearch.containingFile is GtsFile) {
-                consumer.process(ResolvedReference(myQueryParameters.elementToSearch, myQueryParameters.elementToSearch))
+            if (myElementToSearch.containingFile is GtsFile) {
+                consumer.process(ResolvedReference(myElementToSearch, myElementToSearch))
                 return false
             }
             return if ((element is HbPsiElement && element.elementType == HbTokenTypes.ID) || (element is XmlToken && element.parent is HtmlTag)) {
                 val elem = (element is XmlToken && element.parent is HtmlTag).ifTrue { element.parent } ?: element
-                var found = elem.reference?.isReferenceTo(myQueryParameters.elementToSearch) == true || elem.references.any {
-                    it.isReferenceTo(myQueryParameters.elementToSearch)
+                var foundRef = (elem.reference?.isReferenceTo(myElementToSearch) == true).ifTrue { elem.reference } ?: elem.references.find {
+                    it.isReferenceTo(myElementToSearch)
                 }
 
-                if (!found) {
-                    var resolved = elem.reference?.resolve()
-                    if (resolved is EmberNamedElement) {
-                        resolved = resolved.target
-                    }
-                    if (resolved == myQueryParameters.elementToSearch) {
-                        return false
-                    }
-                    found = (resolved as? ES6ImportSpecifier)?.let {
-                        val results = it.multiResolve(false)
-                        results.any { it.element == myQueryParameters.elementToSearch }
-                    } ?: false
+                if (foundRef != null) {
+                    consumer.process(foundRef)
+                    return false
                 }
-                if (!found) {
-                    var resolved = elem.references.find { it.resolve() is ES6ImportSpecifier || it.resolve() is EmberNamedElement }?.resolve()
-                    if (resolved is EmberNamedElement) {
-                        resolved = resolved.target
-                    }
-                    if (resolved == myQueryParameters.elementToSearch) {
-                        return false
-                    }
-                     found = (resolved as? ES6ImportSpecifier)?.let {
-                        val results = it.multiResolve(false)
-                        results.any { it.element == myQueryParameters.elementToSearch }
-                    } ?: false
+
+                var resolved = elem.reference?.resolve()
+                if (resolved is EmberNamedElement) {
+                    resolved = resolved.target
+                }
+                if (resolved == myElementToSearch) {
+                    foundRef = elem.reference
+                    consumer.process(foundRef)
+                    return false
+                }
+                foundRef = (resolved as? ES6ImportSpecifier)?.let {
+                    val results = it.multiResolve(false)
+                    results.find { it.element == myElementToSearch }?.let { ResolvedReference(element, myElementToSearch) }
+                }
+                if (foundRef != null) {
+                    consumer.process(foundRef)
+                    return false
+                }
+                val ref = elem.references.find { it.resolve() is ES6ImportSpecifier || it.resolve() is EmberNamedElement }
+                resolved = ref?.resolve()
+                if (resolved is EmberNamedElement) {
+                    resolved = resolved.target
+                }
+                if (resolved == myElementToSearch) {
+                    consumer.process(ref)
+                    return false
+                }
+                val found = (resolved as? ES6ImportSpecifier)?.let {
+                   val results = it.multiResolve(false)
+                   results.any { it.element == myElementToSearch }
+               } ?: false
+                if (found) {
+                    consumer.process(ref)
                 }
                 return !found
             } else {

--- a/src/main/kotlin/com/emberjs/gts/GtsSupport.kt
+++ b/src/main/kotlin/com/emberjs/gts/GtsSupport.kt
@@ -130,6 +130,8 @@ class GtsFile(viewProvider: FileViewProvider?, val isJS: Boolean =false)
     override fun toString(): String {
         return "GTS File"
     }
+
+
 }
 
 

--- a/src/test/kotlin/com/emberjs/gts/GtsFileTest.kt
+++ b/src/test/kotlin/com/emberjs/gts/GtsFileTest.kt
@@ -5,6 +5,7 @@ import com.emberjs.gts.GtsFileType
 import com.intellij.codeInsight.daemon.impl.HighlightInfo
 import com.intellij.lang.javascript.inspections.ES6UnusedImportsInspection
 import com.intellij.lang.javascript.inspections.JSUnusedLocalSymbolsInspection
+import com.intellij.lang.javascript.inspections.JSUnusedGlobalSymbolsInspection
 import com.intellij.lang.javascript.psi.impl.JSFileImpl
 import com.intellij.testFramework.IndexingTestUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
@@ -54,7 +55,7 @@ class GtsFileTest : BasePlatformTestCase() {
             </template>
         """.trimIndent()
         myFixture.configureByText(GjsFileType.INSTANCE, gts)
-        myFixture.enableInspections(ES6UnusedImportsInspection(), JSUnusedLocalSymbolsInspection())
+        myFixture.enableInspections(ES6UnusedImportsInspection(), JSUnusedLocalSymbolsInspection(), JSUnusedGlobalSymbolsInspection())
         CodeInsightTestFixtureImpl.ensureIndexesUpToDate(project)
         val highlightInfos: List<HighlightInfo> = myFixture.doHighlighting().filter { it.inspectionToolId == "ES6UnusedImports" || it.inspectionToolId == "JSUnusedLocalSymbols" }
         TestCase.assertEquals(4, highlightInfos.size)

--- a/src/test/kotlin/com/emberjs/gts/GtsFileTest.kt
+++ b/src/test/kotlin/com/emberjs/gts/GtsFileTest.kt
@@ -40,10 +40,13 @@ class GtsFileTest : BasePlatformTestCase() {
             function corge() {};
             function corge2() {};
             
+            export const grault = {}; 
+            export const Grault = {}; 
             
             export default <template>
                 <Foo />
                 <Baz />
+                <Grault />
                 {{x}}
                 {{y}}
                 {{corge}}
@@ -71,14 +74,16 @@ class GtsFileTest : BasePlatformTestCase() {
             
             const bar = () => null;
             
-            const Baz = {};
+            const Baz = {};           
             
             export default <template>
                 <Foo />
                 <Baz />
+                <Grault />
                 {{x}}
                 {{y}}
                 {{bar}}
+                {{grault}}
             </template>
         """.trimIndent()
         myFixture.configureByText(GtsFileType.INSTANCE, gts)

--- a/src/test/kotlin/com/emberjs/gts/GtsFileTest.kt
+++ b/src/test/kotlin/com/emberjs/gts/GtsFileTest.kt
@@ -41,7 +41,7 @@ class GtsFileTest : BasePlatformTestCase() {
             function corge() {};
             function corge2() {};
             
-            export const grault = {}; 
+            export const grault2 = {}; 
             export const Grault = {}; 
             
             export default <template>
@@ -52,15 +52,17 @@ class GtsFileTest : BasePlatformTestCase() {
                 {{y}}
                 {{corge}}
                 {{bar}}
+                {{grault2}}
             </template>
         """.trimIndent()
         myFixture.configureByText(GjsFileType.INSTANCE, gts)
         myFixture.enableInspections(ES6UnusedImportsInspection(), JSUnusedLocalSymbolsInspection(), JSUnusedGlobalSymbolsInspection())
         CodeInsightTestFixtureImpl.ensureIndexesUpToDate(project)
-        val unusedConstants = myFixture.doHighlighting().filter { it.description.startsWith("unused constant") }
-        TestCase.assertEquals(unusedConstants.size, 0)
-        val highlightInfos: List<HighlightInfo> = myFixture.doHighlighting().filter { it.inspectionToolId == "ES6UnusedImports" || it.inspectionToolId == "JSUnusedLocalSymbols" }
-        TestCase.assertEquals(4, highlightInfos.size)
+        val highlighting = myFixture.doHighlighting()
+        val unusedConstants = highlighting.filter { it.description?.startsWith("Unused constant") == true }
+        TestCase.assertEquals(unusedConstants.toString(), 2, unusedConstants.size)
+        val highlightInfos: List<HighlightInfo> = highlighting.filter { it.inspectionToolId == "ES6UnusedImports" || it.inspectionToolId == "JSUnusedLocalSymbols" }
+        TestCase.assertEquals(highlighting.toString(), 4, highlightInfos.size)
         TestCase.assertTrue(highlightInfos[0].description.contains("quux"))
         TestCase.assertTrue(highlightInfos[1].description.contains("qux"))
         TestCase.assertTrue(highlightInfos[2].description.contains("grault"))
@@ -89,15 +91,17 @@ class GtsFileTest : BasePlatformTestCase() {
                 {{x}}
                 {{y}}
                 {{bar}}
-                {{grault}}q
+                {{grault}}
             </template>
         """.trimIndent()
         myFixture.configureByText(GtsFileType.INSTANCE, gts)
         myFixture.enableInspections(ES6UnusedImportsInspection(), JSUnusedLocalSymbolsInspection(), JSUnusedGlobalSymbolsInspection())
         CodeInsightTestFixtureImpl.ensureIndexesUpToDate(project)
-        val unusedConstants = myFixture.doHighlighting().filter { it.description.startsWith("unused constant") }
-        TestCase.assertEquals(unusedConstants.size, 0)
-        val highlightInfos: List<HighlightInfo> = myFixture.doHighlighting().filter { it.inspectionToolId == "ES6UnusedImports" }
+        val highlighting = myFixture.doHighlighting()
+        System.out.println(highlighting)
+        val unusedConstants = highlighting.filter { it.description?.startsWith("Unused constant") == true }
+        TestCase.assertEquals(unusedConstants.toString(), 0, unusedConstants.size)
+        val highlightInfos: List<HighlightInfo> = highlighting.filter { it.inspectionToolId == "ES6UnusedImports" }
         TestCase.assertEquals(highlightInfos.size, 2)
         TestCase.assertTrue(highlightInfos.first().description.contains("quux"))
         TestCase.assertTrue(highlightInfos.last().description.contains("qux"))

--- a/src/test/kotlin/com/emberjs/gts/GtsFileTest.kt
+++ b/src/test/kotlin/com/emberjs/gts/GtsFileTest.kt
@@ -4,10 +4,9 @@ import com.emberjs.gts.GjsFileType
 import com.emberjs.gts.GtsFileType
 import com.intellij.codeInsight.daemon.impl.HighlightInfo
 import com.intellij.lang.javascript.inspections.ES6UnusedImportsInspection
-import com.intellij.lang.javascript.inspections.JSUnusedLocalSymbolsInspection
 import com.intellij.lang.javascript.inspections.JSUnusedGlobalSymbolsInspection
+import com.intellij.lang.javascript.inspections.JSUnusedLocalSymbolsInspection
 import com.intellij.lang.javascript.psi.impl.JSFileImpl
-import com.intellij.testFramework.IndexingTestUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
 import junit.framework.TestCase
@@ -62,11 +61,12 @@ class GtsFileTest : BasePlatformTestCase() {
         val unusedConstants = highlighting.filter { it.description?.startsWith("Unused constant") == true }
         TestCase.assertEquals(unusedConstants.toString(), 2, unusedConstants.size)
         val highlightInfos: List<HighlightInfo> = highlighting.filter { it.inspectionToolId == "ES6UnusedImports" || it.inspectionToolId == "JSUnusedLocalSymbols" }
-        TestCase.assertEquals(highlighting.toString(), 4, highlightInfos.size)
-        TestCase.assertTrue(highlightInfos[0].description.contains("quux"))
-        TestCase.assertTrue(highlightInfos[1].description.contains("qux"))
-        TestCase.assertTrue(highlightInfos[2].description.contains("grault"))
-        TestCase.assertTrue(highlightInfos[3].description.contains("corge2"))
+        TestCase.assertEquals(highlighting.toString(), 5, highlightInfos.size)
+        TestCase.assertTrue(highlightInfos[0].description, highlightInfos[0].description.contains("quux"))
+        TestCase.assertTrue(highlightInfos[1].description, highlightInfos[1].description.contains("qux"))
+        TestCase.assertTrue(highlightInfos[2].description, highlightInfos[2].description.contains("grault"))
+        TestCase.assertTrue(highlightInfos[3].description, highlightInfos[3].description.contains("grault"))
+        TestCase.assertTrue(highlightInfos[4].description, highlightInfos[4].description.contains("corge2"))
     }
 
     @Test

--- a/src/test/kotlin/com/emberjs/gts/GtsFileTest.kt
+++ b/src/test/kotlin/com/emberjs/gts/GtsFileTest.kt
@@ -57,6 +57,8 @@ class GtsFileTest : BasePlatformTestCase() {
         myFixture.configureByText(GjsFileType.INSTANCE, gts)
         myFixture.enableInspections(ES6UnusedImportsInspection(), JSUnusedLocalSymbolsInspection(), JSUnusedGlobalSymbolsInspection())
         CodeInsightTestFixtureImpl.ensureIndexesUpToDate(project)
+        val unusedConstants = myFixture.doHighlighting().filter { it.description.startsWith("unused constant") }
+        TestCase.assertEquals(unusedConstants.size, 0)
         val highlightInfos: List<HighlightInfo> = myFixture.doHighlighting().filter { it.inspectionToolId == "ES6UnusedImports" || it.inspectionToolId == "JSUnusedLocalSymbols" }
         TestCase.assertEquals(4, highlightInfos.size)
         TestCase.assertTrue(highlightInfos[0].description.contains("quux"))
@@ -75,7 +77,10 @@ class GtsFileTest : BasePlatformTestCase() {
             
             const bar = () => null;
             
-            const Baz = {};           
+            const Baz = {};
+            
+            export const grault = {}; 
+            export const Grault = {}; 
             
             export default <template>
                 <Foo />
@@ -84,12 +89,14 @@ class GtsFileTest : BasePlatformTestCase() {
                 {{x}}
                 {{y}}
                 {{bar}}
-                {{grault}}
+                {{grault}}q
             </template>
         """.trimIndent()
         myFixture.configureByText(GtsFileType.INSTANCE, gts)
-        myFixture.enableInspections(ES6UnusedImportsInspection())
+        myFixture.enableInspections(ES6UnusedImportsInspection(), JSUnusedLocalSymbolsInspection(), JSUnusedGlobalSymbolsInspection())
         CodeInsightTestFixtureImpl.ensureIndexesUpToDate(project)
+        val unusedConstants = myFixture.doHighlighting().filter { it.description.startsWith("unused constant") }
+        TestCase.assertEquals(unusedConstants.size, 0)
         val highlightInfos: List<HighlightInfo> = myFixture.doHighlighting().filter { it.inspectionToolId == "ES6UnusedImports" }
         TestCase.assertEquals(highlightInfos.size, 2)
         TestCase.assertTrue(highlightInfos.first().description.contains("quux"))


### PR DESCRIPTION
when a const or function is used in a template and exported it was marked as unused