### PR TITLE
limit ember template lint processing to correct files

### DIFF
--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintExternalAnnotator.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintExternalAnnotator.kt
@@ -32,7 +32,14 @@ class TemplateLintExternalAnnotator(onTheFly: Boolean = true) : JSLinterExternal
 
     override fun acceptPsiFile(file: PsiFile): Boolean {
         val f = file
-        return f.viewProvider is GtsFileViewProvider || f.viewProvider is HbFileViewProvider || file is JSFile
+        val pkg = TemplateLintConfiguration.getInstance(file.project).extendedState.state.templateLintPackage
+        val supportsJS = pkg.version?.let { it.major < 8 } ?: false
+        return (f.name.endsWith(".hbs")
+                || (f.name.endsWith(".js") && supportsJS)
+                || (f.name.endsWith(".ts") && supportsJS)
+                || f.name.endsWith(".gjs")
+                || f.name.endsWith(".gts"))
+                && f.name.endsWith(".d.ts")
     }
 
     override fun annotate(input: JSLinterInput<TemplateLintState>): JSLinterAnnotationResult? {

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintExternalAnnotator.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintExternalAnnotator.kt
@@ -39,7 +39,7 @@ class TemplateLintExternalAnnotator(onTheFly: Boolean = true) : JSLinterExternal
                 || (f.name.endsWith(".ts") && supportsJS)
                 || f.name.endsWith(".gjs")
                 || f.name.endsWith(".gts"))
-                && f.name.endsWith(".d.ts")
+                && !f.name.endsWith(".d.ts")
     }
 
     override fun annotate(input: JSLinterInput<TemplateLintState>): JSLinterAnnotationResult? {

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintFixAction.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintFixAction.kt
@@ -68,7 +68,7 @@ class TemplateLintFixAction : JSLinterFixAction(
                 || (f.name.endsWith(".ts") && supportsJS)
                 || f.name.endsWith(".gjs")
                 || f.name.endsWith(".gts"))
-                && f.name.endsWith(".d.ts")
+                && !f.name.endsWith(".d.ts")
     }
 
     private fun fixFile(psiFile: PsiFile) {

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintFixAction.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintFixAction.kt
@@ -60,8 +60,15 @@ class TemplateLintFixAction : JSLinterFixAction(
     }
 
     override fun isFileAccepted(project: Project, file: VirtualFile): Boolean {
-        val f = PsiManager.getInstance(project).findFile(file)
-        return f?.viewProvider is GtsFileViewProvider || f?.viewProvider is HbFileViewProvider || f is JSFile
+        val f = PsiManager.getInstance(project).findFile(file) ?: return false
+        val pkg = TemplateLintConfiguration.getInstance(project).extendedState.state.templateLintPackage
+        val supportsJS = pkg.version?.let { it.major < 8 } ?: false
+        return (f.name.endsWith(".hbs")
+                || (f.name.endsWith(".js") && supportsJS)
+                || (f.name.endsWith(".ts") && supportsJS)
+                || f.name.endsWith(".gjs")
+                || f.name.endsWith(".gts"))
+                && f.name.endsWith(".d.ts")
     }
 
     private fun fixFile(psiFile: PsiFile) {


### PR DESCRIPTION
fixes #222 

according to discord discussion, e-template-lint < 8 should support js/ts, but variations like mjs/cjs are not.
at v8 it's planned to completely drop support for js and move to only support gjs/gts