### PR TITLE
fix glint duplicate error reporting

### DIFF
--- a/src/main/kotlin/com/emberjs/gts/GlintExternalAnnotator.kt
+++ b/src/main/kotlin/com/emberjs/gts/GlintExternalAnnotator.kt
@@ -226,7 +226,7 @@ class GlintExternalAnnotator : JSLinterExternalAnnotator<GlintState>(true) {
         }
 
         val errors: MutableList<JSLinterError> = mutableListOf()
-        errors.addAll(res?.map { JSLinterError(it.line, it.column, it.description, it.category, it.severity) } ?: listOf())
+        errors.addAll(res?.map { JSLinterError(it.line + 1, it.column, it.description, it.category, it.severity) } ?: listOf())
         return JSLinterAnnotationResult.createLinterResult(input, errors.toList(), null as VirtualFile?)
     }
 

--- a/src/main/kotlin/com/emberjs/gts/GtsSupport.kt
+++ b/src/main/kotlin/com/emberjs/gts/GtsSupport.kt
@@ -49,6 +49,7 @@ import com.intellij.lexer.Lexer
 import com.intellij.lexer.LookAheadLexer
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.actions.lists.TrailingComma
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.ex.util.LayerDescriptor
 import com.intellij.openapi.editor.ex.util.LayeredLexerEditorHighlighter
@@ -126,6 +127,7 @@ class GjsLanguage(): GtsLanguage(JS, "Gjs") {
 
 class GtsFile(viewProvider: FileViewProvider?, val isJS: Boolean =false)
     : JSFileImpl(viewProvider!!, isJS.ifTrue { GjsLanguage.INSTANCE } ?: GtsLanguage.INSTANCE) {
+
     override fun getFileType(): FileType {
         return isJS.ifTrue { GjsFileType.INSTANCE } ?: GtsFileType.INSTANCE
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -176,7 +176,6 @@
         <externalAnnotator language="Handlebars" implementationClass="TemplateLintExternalAnnotator"/>
         <externalAnnotator language="JavaScript" implementationClass="TemplateLintExternalAnnotator"/>
         <externalAnnotator language="Gts" implementationClass="TemplateLintExternalAnnotator"/>
-        <externalAnnotator language="Gts" implementationClass="com.emberjs.gts.GlintExternalAnnotator"/>
         <externalAnnotator language="Handlebars" implementationClass="com.emberjs.gts.HbLintExternalAnnotator"/>
         <externalAnnotator language="Gts" implementationClass="com.emberjs.hbs.linter.eslint.GtsEslintExternalAnnotator"/>
         <externalAnnotator language="Handlebars" implementationClass="com.emberjs.hbs.linter.eslint.GtsEslintExternalAnnotator"/>


### PR DESCRIPTION
remove external annotator from config...
we only need it to run batch inspection

fixes #252 