### PR TITLE
Fix editor freezes from uncached Glint availability checks (#391)

### DIFF
--- a/src/main/kotlin/com/emberjs/glint/GlintLspSupportProvider.kt
+++ b/src/main/kotlin/com/emberjs/glint/GlintLspSupportProvider.kt
@@ -28,13 +28,11 @@ import com.intellij.platform.lsp.api.LspServerManager
 import com.intellij.platform.lsp.api.LspServerSupportProvider
 import com.intellij.psi.PsiManager
 import com.intellij.util.FileContentUtil
-import com.intellij.util.concurrency.AppExecutorUtil
 import org.eclipse.lsp4j.ServerInfo
 import java.io.File
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.util.*
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.concurrent.schedule
 import kotlin.io.path.Path
@@ -64,7 +62,6 @@ class GlintLspServerDescriptor(private val myProject: Project) : LspServerDescri
     var glintCoreDir: VirtualFile? = null
     private data class CachedAvailability(val available: Boolean, val checkedAt: Long)
     private val availabilityCache = ConcurrentHashMap<String, CachedAvailability>()
-    private val pendingAvailabilityChecks = ConcurrentHashMap<String, CompletableFuture<Boolean>>()
 
     public val server
         get() =
@@ -74,9 +71,15 @@ class GlintLspServerDescriptor(private val myProject: Project) : LspServerDescri
      * getAttributeDescriptor/getAttributesDescriptors calls this for every attribute of every
      * tag during highlighting, and on WSL this spawns a blocking `wsl.exe` process, so results
      * are cached for a short time. A short TTL (rather than caching forever) is used so that
-     * e.g. installing @glint/core after the first check is picked up again quickly. Concurrent
-     * callers for the same directory (e.g. multiple highlighting threads at once) are coalesced
-     * onto a single probe instead of each spawning their own subprocess.
+     * e.g. installing @glint/core after the first check is picked up again quickly.
+     *
+     * The actual probe runs synchronously on the calling thread (not dispatched to another
+     * thread) because callers here almost always already hold the read lock (PsiReference
+     * resolution, reference providers, completion contributors). Blocking the caller on a
+     * future computed on a different thread that itself needs to acquire a fresh read lock can
+     * deadlock against a pending write action - the caller holds its read lock while waiting on
+     * `.get()`, the pool thread waits for the write action, and the write action waits for the
+     * caller's read lock to be released.
      */
     fun isAvailableFromDir(file: VirtualFile): Boolean {
         val cacheKey = file.path
@@ -85,16 +88,9 @@ class GlintLspServerDescriptor(private val myProject: Project) : LspServerDescri
         if (cached != null && now - cached.checkedAt < AVAILABILITY_CACHE_TTL_MS) {
             return cached.available
         }
-        val future = pendingAvailabilityChecks.computeIfAbsent(cacheKey) {
-            CompletableFuture.supplyAsync({ computeAvailabilityFromDir(file) }, AppExecutorUtil.getAppExecutorService())
-        }
-        return try {
-            val available = future.get()
-            availabilityCache[cacheKey] = CachedAvailability(available, now)
-            available
-        } finally {
-            pendingAvailabilityChecks.remove(cacheKey, future)
-        }
+        val available = computeAvailabilityFromDir(file)
+        availabilityCache[cacheKey] = CachedAvailability(available, now)
+        return available
     }
 
     private fun computeAvailabilityFromDir(workingDir: VirtualFile): Boolean {

--- a/src/main/kotlin/com/emberjs/glint/GlintLspSupportProvider.kt
+++ b/src/main/kotlin/com/emberjs/glint/GlintLspSupportProvider.kt
@@ -80,17 +80,23 @@ class GlintLspServerDescriptor(private val myProject: Project) : LspServerDescri
      * deadlock against a pending write action - the caller holds its read lock while waiting on
      * `.get()`, the pool thread waits for the write action, and the write action waits for the
      * caller's read lock to be released.
+     *
+     * Concurrent callers for the same path are coalesced via `ConcurrentHashMap.compute`, which
+     * holds the map's per-bucket lock for the whole call: whichever thread finds the cache stale
+     * first runs the probe while any other thread for the *same* key blocks briefly on the map
+     * (not on a cross-thread future) until that result is published, so a burst of callers for
+     * one path still only spawns one `wsl.exe` process per TTL window instead of one per caller.
      */
     fun isAvailableFromDir(file: VirtualFile): Boolean {
         val cacheKey = file.path
-        val cached = availabilityCache[cacheKey]
         val now = System.currentTimeMillis()
-        if (cached != null && now - cached.checkedAt < AVAILABILITY_CACHE_TTL_MS) {
-            return cached.available
-        }
-        val available = computeAvailabilityFromDir(file)
-        availabilityCache[cacheKey] = CachedAvailability(available, now)
-        return available
+        return availabilityCache.compute(cacheKey) { _, existing ->
+            if (existing != null && now - existing.checkedAt < AVAILABILITY_CACHE_TTL_MS) {
+                existing
+            } else {
+                CachedAvailability(computeAvailabilityFromDir(file), now)
+            }
+        }!!.available
     }
 
     private fun computeAvailabilityFromDir(workingDir: VirtualFile): Boolean {

--- a/src/main/kotlin/com/emberjs/glint/GlintLspSupportProvider.kt
+++ b/src/main/kotlin/com/emberjs/glint/GlintLspSupportProvider.kt
@@ -33,8 +33,12 @@ import java.io.File
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.concurrent.schedule
 import kotlin.io.path.Path
+
+private const val AVAILABILITY_CACHE_TTL_MS = 5000L
 
 class GlintLspSupportProvider : LspServerSupportProvider {
     var willStart = false
@@ -57,13 +61,42 @@ class GlintLspServerDescriptor(private val myProject: Project) : LspServerDescri
     var isWsl = false
     var wslDistro = ""
     var glintCoreDir: VirtualFile? = null
+    private data class CachedAvailability(val available: Boolean, val checkedAt: Long)
+    private val availabilityCache = ConcurrentHashMap<String, CachedAvailability>()
+    private val pendingAvailabilityChecks = ConcurrentHashMap<String, CompletableFuture<Boolean>>()
 
     public val server
         get() =
            lspServerManager.getServersForProvider(GlintLspSupportProvider::class.java).firstOrNull()
 
+    /**
+     * getAttributeDescriptor/getAttributesDescriptors calls this for every attribute of every
+     * tag during highlighting, and on WSL this spawns a blocking `wsl.exe` process, so results
+     * are cached for a short time. A short TTL (rather than caching forever) is used so that
+     * e.g. installing @glint/core after the first check is picked up again quickly. Concurrent
+     * callers for the same directory (e.g. multiple highlighting threads at once) are coalesced
+     * onto a single probe instead of each spawning their own subprocess.
+     */
     fun isAvailableFromDir(file: VirtualFile): Boolean {
-        val workingDir = file
+        val cacheKey = file.path
+        val cached = availabilityCache[cacheKey]
+        val now = System.currentTimeMillis()
+        if (cached != null && now - cached.checkedAt < AVAILABILITY_CACHE_TTL_MS) {
+            return cached.available
+        }
+        val future = pendingAvailabilityChecks.computeIfAbsent(cacheKey) {
+            CompletableFuture.supplyAsync { computeAvailabilityFromDir(file) }
+        }
+        return try {
+            val available = future.get()
+            availabilityCache[cacheKey] = CachedAvailability(available, now)
+            available
+        } finally {
+            pendingAvailabilityChecks.remove(cacheKey, future)
+        }
+    }
+
+    private fun computeAvailabilityFromDir(workingDir: VirtualFile): Boolean {
         if (WslPath.isWslUncPath(workingDir.path)) {
             isWsl = true
             val wsl = WslPath.parseWindowsUncPath(workingDir.path)
@@ -83,6 +116,7 @@ class GlintLspServerDescriptor(private val myProject: Project) : LspServerDescri
                     true
                 }
             }
+            return false
         }
         return ApplicationManager.getApplication().runReadAction<Boolean> {
             val glintPkg = workingDir.findFileByRelativePath("node_modules/@glint/core") ?: return@runReadAction false

--- a/src/main/kotlin/com/emberjs/glint/GlintLspSupportProvider.kt
+++ b/src/main/kotlin/com/emberjs/glint/GlintLspSupportProvider.kt
@@ -62,6 +62,7 @@ class GlintLspServerDescriptor(private val myProject: Project) : LspServerDescri
     var glintCoreDir: VirtualFile? = null
     private data class CachedAvailability(val available: Boolean, val checkedAt: Long)
     private val availabilityCache = ConcurrentHashMap<String, CachedAvailability>()
+    private val availabilityProbesInFlight = ConcurrentHashMap.newKeySet<String>()
 
     public val server
         get() =
@@ -81,22 +82,35 @@ class GlintLspServerDescriptor(private val myProject: Project) : LspServerDescri
      * `.get()`, the pool thread waits for the write action, and the write action waits for the
      * caller's read lock to be released.
      *
-     * Concurrent callers for the same path are coalesced via `ConcurrentHashMap.compute`, which
-     * holds the map's per-bucket lock for the whole call: whichever thread finds the cache stale
-     * first runs the probe while any other thread for the *same* key blocks briefly on the map
-     * (not on a cross-thread future) until that result is published, so a burst of callers for
-     * one path still only spawns one `wsl.exe` process per TTL window instead of one per caller.
+     * Concurrent callers for the same path are de-duplicated via `availabilityProbesInFlight`: if
+     * another thread is already probing this path, this call returns the last known result (or
+     * `false` if none yet) immediately instead of running its own probe or waiting for the other
+     * one to finish. This deliberately never blocks one caller on another - holding any lock (an
+     * explicit one, or a `ConcurrentHashMap` bucket lock via `compute`) across the blocking
+     * subprocess call and `runReadAction` below would reintroduce the same deadlock shape as the
+     * `CompletableFuture` approach above: a caller that already holds a read lock could block on
+     * that lock while a write action is waiting for that same read lock to be released. A stale
+     * or momentarily-false result here is harmless - it just means "not available for this
+     * highlighting pass," which corrects itself on the next pass once the in-flight probe
+     * completes and populates the cache.
      */
     fun isAvailableFromDir(file: VirtualFile): Boolean {
         val cacheKey = file.path
         val now = System.currentTimeMillis()
-        return availabilityCache.compute(cacheKey) { _, existing ->
-            if (existing != null && now - existing.checkedAt < AVAILABILITY_CACHE_TTL_MS) {
-                existing
-            } else {
-                CachedAvailability(computeAvailabilityFromDir(file), now)
-            }
-        }!!.available
+        val cached = availabilityCache[cacheKey]
+        if (cached != null && now - cached.checkedAt < AVAILABILITY_CACHE_TTL_MS) {
+            return cached.available
+        }
+        if (!availabilityProbesInFlight.add(cacheKey)) {
+            return cached?.available ?: false
+        }
+        try {
+            val available = computeAvailabilityFromDir(file)
+            availabilityCache[cacheKey] = CachedAvailability(available, System.currentTimeMillis())
+            return available
+        } finally {
+            availabilityProbesInFlight.remove(cacheKey)
+        }
     }
 
     private fun computeAvailabilityFromDir(workingDir: VirtualFile): Boolean {

--- a/src/main/kotlin/com/emberjs/glint/GlintLspSupportProvider.kt
+++ b/src/main/kotlin/com/emberjs/glint/GlintLspSupportProvider.kt
@@ -116,7 +116,6 @@ class GlintLspServerDescriptor(private val myProject: Project) : LspServerDescri
                     true
                 }
             }
-            return false
         }
         return ApplicationManager.getApplication().runReadAction<Boolean> {
             val glintPkg = workingDir.findFileByRelativePath("node_modules/@glint/core") ?: return@runReadAction false

--- a/src/main/kotlin/com/emberjs/glint/GlintLspSupportProvider.kt
+++ b/src/main/kotlin/com/emberjs/glint/GlintLspSupportProvider.kt
@@ -28,6 +28,7 @@ import com.intellij.platform.lsp.api.LspServerManager
 import com.intellij.platform.lsp.api.LspServerSupportProvider
 import com.intellij.psi.PsiManager
 import com.intellij.util.FileContentUtil
+import com.intellij.util.concurrency.AppExecutorUtil
 import org.eclipse.lsp4j.ServerInfo
 import java.io.File
 import java.net.URLEncoder
@@ -85,7 +86,7 @@ class GlintLspServerDescriptor(private val myProject: Project) : LspServerDescri
             return cached.available
         }
         val future = pendingAvailabilityChecks.computeIfAbsent(cacheKey) {
-            CompletableFuture.supplyAsync { computeAvailabilityFromDir(file) }
+            CompletableFuture.supplyAsync({ computeAvailabilityFromDir(file) }, AppExecutorUtil.getAppExecutorService())
         }
         return try {
             val available = future.get()

--- a/src/main/kotlin/com/emberjs/xml/EmberXmlElementDescriptor.kt
+++ b/src/main/kotlin/com/emberjs/xml/EmberXmlElementDescriptor.kt
@@ -10,6 +10,7 @@ import com.emberjs.utils.EmberUtils
 import com.emberjs.utils.originalVirtualFile
 import com.intellij.lang.javascript.psi.JSFile
 import com.intellij.lang.javascript.psi.JSNamedElement
+import com.intellij.openapi.project.DumbService
 import com.intellij.psi.*
 import com.intellij.psi.impl.FakePsiElement
 import com.intellij.psi.impl.source.html.dtd.HtmlNSDescriptorImpl
@@ -122,7 +123,9 @@ class EmberXmlElementDescriptor(private val tag: XmlTag, private val declaration
 
     override fun getAttributesDescriptors(context: XmlTag?): Array<out XmlAttributeDescriptor> {
         val result = mutableListOf<XmlAttributeDescriptor>()
-        val commonHtmlAttributes = HtmlNSDescriptorImpl.getCommonAttributeDescriptors(this.tag)
+        // HtmlNSDescriptorImpl.getCommonAttributeDescriptors queries FileBasedIndex without a
+        // dumb-mode guard of its own, throwing IndexNotReadyException while indexing.
+        val commonHtmlAttributes = if (DumbService.isDumb(project)) emptyArray() else HtmlNSDescriptorImpl.getCommonAttributeDescriptors(this.tag)
         val data = getReferenceData()
         val attributes = data.args.map { EmberAttributeDescriptor(this.tag, it.value, false, it.description, it.reference, null)  }
         result.addAll(attributes)

--- a/src/test/kotlin/com/emberjs/xml/EmberXmlElementDescriptorTest.kt
+++ b/src/test/kotlin/com/emberjs/xml/EmberXmlElementDescriptorTest.kt
@@ -1,0 +1,40 @@
+package com.emberjs.xml
+
+import com.dmarcotte.handlebars.file.HbFileType
+import com.intellij.lang.Language
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.xml.XmlTag
+import com.intellij.testFramework.DumbModeTestUtils
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.junit.Test
+
+class EmberXmlElementDescriptorTest : BasePlatformTestCase() {
+
+    private fun findDivTag(): XmlTag {
+        myFixture.configureByText(HbFileType.INSTANCE, "<div></div>")
+        val htmlView = myFixture.file.viewProvider.getPsi(Language.findLanguageByID("HTML")!!)
+        return PsiTreeUtil.collectElements(htmlView) { it is XmlTag && it.name == "div" }.first() as XmlTag
+    }
+
+    @Test
+    fun testGetAttributesDescriptorsIncludesCommonHtmlAttributesInSmartMode() {
+        val tag = findDivTag()
+        val descriptor = EmberXmlElementDescriptor(tag, null)
+
+        val attributes = descriptor.getAttributesDescriptors(tag)
+
+        assertTrue(attributes.isNotEmpty())
+        assertTrue(attributes.any { it.getName() == "class" })
+    }
+
+    @Test
+    fun testGetAttributesDescriptorsSkipsCommonHtmlAttributesInDumbMode() {
+        val tag = findDivTag()
+        val descriptor = EmberXmlElementDescriptor(tag, null)
+
+        DumbModeTestUtils.runInDumbModeSynchronously(project) {
+            val attributes = descriptor.getAttributesDescriptors(tag)
+            assertTrue(attributes.isEmpty())
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #391 (WebStorm/IntelliJ unresponsive after upgrading to 2026.1.0).

- `EmberXmlElementDescriptor.getAttributeDescriptor()`/`getAttributesDescriptors()` call `GlintLspServerDescriptor.isAvailableFromDir()` for every attribute of every tag during highlighting. On WSL this spawns a blocking `wsl.exe` subprocess with **no caching**, and the reporter's own IDE thread dump shows 4 `JobScheduler FJ pool` threads simultaneously blocked in `ProcessImpl.waitForInterruptibly`, causing multi-second (7s+) editor freezes.
- **Confirmed root cause / regression source**: v2025.3.1 had a permanent per-directory availability cache added by #361 (March 2026). Commit bf87172 (part of #388, "Support IntelliJ IDEA 2026.1", released as **v2026.1.0** — the exact version the reporter has installed) dropped that cache entirely while fixing an unrelated issue (the old cache never invalidated, and wrapped a blocking subprocess call inside a read action). That drop reintroduced the uncached blocking call this issue describes. bf87172's own commit message attributes the cache to "the 2026.1 platform bump," but git history shows it actually predates that work (#361, unrelated to the platform bump).
- Fix: restore caching for `isAvailableFromDir`, but with a short TTL (5s) instead of a permanent cache, so installing `@glint/core` after the first check is picked up again quickly (the concern that motivated dropping the old cache).
- Concurrent callers for the same directory are de-duplicated so a burst of callers spawns at most one probe per TTL window instead of one each. This design went through a few iterations during review, each fixing a deadlock the previous one introduced:
  - `computeIfAbsent` + `CompletableFuture`: blocked other callers on `.get()` for a future computed on another thread. Deadlocked because the calling thread usually already holds a read lock (PsiReference resolution, reference providers, completion contributors), and blocking it on a future that itself needs a fresh read action can deadlock against a pending write action.
  - `ConcurrentHashMap.compute()`: runs the probe synchronously on the calling thread instead, so no cross-thread hand-off — but `compute()` holds the map's per-bucket lock for the whole call, including the blocking subprocess call and `runReadAction`. That reintroduces the same deadlock shape: a caller without a read lock takes the bucket lock and blocks in `runReadAction` behind a pending write action, while a caller that already holds a read lock blocks on that same bucket lock — and the write action can't proceed until that read lock is released.
  - **Current implementation**: a plain `ConcurrentHashMap.newKeySet()` tracking in-flight probes. A caller that finds a probe already running for its path returns the last cached result (or `false` if there isn't one yet) immediately, instead of waiting for it. No thread ever blocks on another thread's probe or holds a lock across the subprocess call, so a burst of callers for one path still spawns only one `wsl.exe` process per TTL window, but with no deadlock potential. The tradeoff: a concurrent caller can get a transient `false` for one highlighting pass, which self-corrects on the next pass — harmless, since `isAvailable()` already returns `false` routinely while walking parent directories.
- Also addressed the report's corroborating issue #1: `EmberXmlElementDescriptor.getAttributesDescriptors()` called `HtmlNSDescriptorImpl.getCommonAttributeDescriptors()` unconditionally, which queries `FileBasedIndex` without its own dumb-mode guard and threw `IndexNotReadyException` repeatedly during indexing. Now skipped while `DumbService.isDumb(project)`, with test coverage (`EmberXmlElementDescriptorTest`) asserting the guard applies in dumb mode and common HTML attributes still appear otherwise.

**Out of scope**: the report's corroborating issue #3 (`GtsEslintExternalAnnotator` failing to load because `com.intellij.lang.javascript.linter.eslint.EslintExternalAnnotator` doesn't exist) is on WebStorm 2026.2 (build 262), a platform version this plugin isn't built/tested against yet (current support tops out at 2026.1/build 261). That needs its own platform-version bump, not a fix within this change.

## Test plan
- [x] `./gradlew compileKotlin` — compiles clean
- [x] `./gradlew test --rerun --continue` — 208/208 passing, no regressions, including new `EmberXmlElementDescriptorTest` coverage for the dumb-mode guard
- Note: `GlintLspServerDescriptor.isAvailable()` short-circuits to `false` under `ApplicationManager.isUnitTestMode`, so no test exercises `isAvailableFromDir`/the TTL cache/single-flight de-dup directly (the WSL subprocess path isn't practical to test in this harness); the passing suite means "no regression," not "freeze fix verified under test." Manual verification would require a WSL-hosted project with `@glint/core` installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
